### PR TITLE
Fix deprecation warning on PHP 8.2 - ${path}

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
@@ -122,7 +122,7 @@ class LangJsGenerator
         $path = $this->sourcePath;
 
         if (!$this->file->exists($path)) {
-            throw new \Exception("${path} doesn't exists!");
+            throw new \Exception("{$path} doesn't exists!");
         }
 
         foreach ($this->file->allFiles($path) as $file) {


### PR DESCRIPTION
Replace ${path} with {$path} because of deprecation warnings